### PR TITLE
Replace excel macro with R functionality

### DIFF
--- a/R/parse_MEA_data.R
+++ b/R/parse_MEA_data.R
@@ -97,7 +97,6 @@ clean_content <- function(df){
     as.data.frame()
   names(df) <- df[1,]
   df <- df[2:nrow(df),]
-
   df <- dplyr::rename(df, ID = 1)
 
   # make the data numeric


### PR DESCRIPTION
This PR essentially replaces the macro originally written in Matlab, in that it takes an output MEA file and parses it into three elements:
1. Header information
2. Well averages df
3. Electrode measurement df

Currently, these functions do not have tests, and they are not complete.
Future steps will be:
1. Complete this step in the analysis by adding either functionality to save the raw data, or calculate the differences between a baseline and exposure file, and save this data (preferably both!)
2. Document the function with Roxygen (only the parse_MEA_data function should be user accessible)
2. Write tests for the functions in this PR.